### PR TITLE
Graft WiiSOAP to EC's expected request behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+config.xml

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,5 @@
-module github.com/Apfel/WiiSOAP
+module github.com/morenatsu-net/WiiSOAP
 
 go 1.12
 
-require (
-	github.com/go-sql-driver/mysql v1.4.1
-	google.golang.org/appengine v1.6.5 // indirect
-)
+require github.com/go-sql-driver/mysql v1.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,11 +1,2 @@
-github.com/go-sql-driver/mysql v1.4.1 h1:g24URVg0OFbNUTx9qqY1IRZ9D9z3iPyi5zKhQZpNwpA=
-github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
-github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
-golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-google.golang.org/appengine v1.6.5 h1:tycE03LOZYQNhDpS27tcQdAzLCVMaj7QT2SXxebnpCM=
-google.golang.org/appengine v1.6.5/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCIDZVag1xfc=
+github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
+github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=


### PR DESCRIPTION
I had nginx proxy my ecs subdomain to WiiSOAP, and used `ec.checkDeviceStatus()` from within the Wii Shop Channel.

OSReport suggests EC was happy about responses as-is:
> CheckDeviceStatus result:
env.forceSyncTime:0  forceSyncTime:0
env.extTicketTime:0  extTicketTime:1595895285000
env.syncTime:1590303477000       syncTime:1595895285000
lastTicketSyncTime:1590303477000
isSyncTimesMatch:0  isNeedTicketSync:1
isNeedTicketSyncImportAll:1